### PR TITLE
ci: disable shallow clone for sonarcloud analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Modify `.github/workflows/ci.yml` to set `fetch-depth: 0` in the `actions/checkout` step. This disables shallow clones and allows SonarCloud to access SCM information.

---
*PR created automatically by Jules for task [9187368201112346901](https://jules.google.com/task/9187368201112346901) started by @karlosarr*