### PR TITLE
docs: add pokedexapp example to github actions

### DIFF
--- a/docs/cicd/github/android.md
+++ b/docs/cicd/github/android.md
@@ -99,3 +99,7 @@ Uploads the signed AAB as a workflow artifact so it can be downloaded.
     name: Signed app bundle
     path: ${{steps.sign_app.outputs.signedReleaseFile}}
 ```
+
+## Example Repository
+
+A complete example of this workflow can be found in the [karlosarr/pokedexapp](https://github.com/karlosarr/pokedexapp) repository.

--- a/docs/cicd/github/ios.md
+++ b/docs/cicd/github/ios.md
@@ -60,3 +60,7 @@ Builds the Xcode project using the selected scheme. The build is performed witho
     file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
     xcodebuild clean build -workspace SwiftAppiOS.xcworkspace -scheme SwiftAppiOS -configuration Release -sdk 'iphoneos' CODE_SIGNING_ALLOWED=NO | xcpretty && exit ${PIPESTATUS[0]}
 ```
+
+## Example Repository
+
+A complete example of this workflow can be found in the [karlosarr/pokedexapp](https://github.com/karlosarr/pokedexapp) repository.

--- a/docs/es-mx/cicd/github/android.md
+++ b/docs/es-mx/cicd/github/android.md
@@ -99,3 +99,7 @@ Sube el AAB firmado como un artefacto del flujo de trabajo para que pueda ser de
     name: Signed app bundle
     path: ${{steps.sign_app.outputs.signedReleaseFile}}
 ```
+
+## Repositorio de Ejemplo
+
+Puedes encontrar un ejemplo completo de este flujo de trabajo en el repositorio [karlosarr/pokedexapp](https://github.com/karlosarr/pokedexapp).

--- a/docs/es-mx/cicd/github/ios.md
+++ b/docs/es-mx/cicd/github/ios.md
@@ -60,3 +60,7 @@ Compila el proyecto de Xcode utilizando el esquema seleccionado. La compilación
     file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
     xcodebuild clean build -workspace SwiftAppiOS.xcworkspace -scheme SwiftAppiOS -configuration Release -sdk 'iphoneos' CODE_SIGNING_ALLOWED=NO | xcpretty && exit ${PIPESTATUS[0]}
 ```
+
+## Repositorio de Ejemplo
+
+Puedes encontrar un ejemplo completo de este flujo de trabajo en el repositorio [karlosarr/pokedexapp](https://github.com/karlosarr/pokedexapp).


### PR DESCRIPTION
Added a reference to the `karlosarr/pokedexapp` repository as a practical example for the Android and iOS GitHub Actions workflows in the CI/CD documentation. Both English and Spanish versions of the documentation were updated.

---
*PR created automatically by Jules for task [11670022764724117479](https://jules.google.com/task/11670022764724117479) started by @karlosarr*